### PR TITLE
Add .env example and README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# Proyecto Practica
+
+## Environment Setup
+
+1. Copy the example environment file:
+   ```bash
+   cp backend/.env.example backend/.env
+   ```
+2. Edit `backend/.env` and replace the placeholder values with your real `MONGO_URI` and `JWT_SECRET`.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+MONGO_URI=your_mongo_uri_here
+JWT_SECRET=your_jwt_secret_here


### PR DESCRIPTION
## Summary
- add example environment file for backend
- document copying `.env.example` to `.env` and setting real values

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881b4605bd88331b333c233aa522cb6